### PR TITLE
Add static tabzilla tab to firefox family landing page.

### DIFF
--- a/bedrock/firefox/templates/firefox/family/index.html
+++ b/bedrock/firefox/templates/firefox/family/index.html
@@ -24,38 +24,46 @@
 
 {% block body_class %}mozid{% endblock %}
 
-{% block site_header %}{% endblock %}
+{% block site_header %}
+  <div id="conditional-download-bar">
+    <div class="content">
+      <div class="message" id="dlbar-oldfx-desktop">
+        {{ _('You’re using an older version of Firefox for desktop.') }}
+        {{ _('Update today to stay fast and safe.') }}
+        <a class="button-flat btn-download" href="{{ url('firefox.new') }}" data-product="Firefox for Desktop, outdated Firefox">{{ _('Download') }}</a>
+      </div>
+      <div class="message" id="dlbar-nonfx">
+        {{ _('Choose Independent.') }}
+        {{ _('Choose Firefox.') }}
+        <a class="button-flat btn-download" href="{{ url('firefox.new') }}" data-product="Firefox for Desktop, other browser">{{ _('Download') }}</a>
+      </div>
+      <div class="message" id="dlbar-nonfx-android">
+        <a rel="external" href="{{ settings.GOOGLE_PLAY_FIREFOX_LINK }}" data-product="Firefox for Android">{{ _('Get Firefox for Android') }}</a>
+      </div>
+      <div class="message" id="dlbar-ios">
+        {{ _('Firefox is coming soon to iOS! <a href="%s">Sign up to learn more</a>.')|format(url('newsletter.ios')) }}
+      </div>
+
+      <button type="button" class="btn-close button-flat" title="{{ _('Close') }}">{{ _('Close') }}</button>
+    </div>{#-- /.content --#}
+  </div>{#-- /#conditional-download-bar --#}
+  <header id="masthead">
+    {% block tabzilla_tab %}
+    <div class="content">
+      <div id="tabzilla">
+        <a href="{{ url('mozorg.home') }}">Mozilla</a>
+      </div>
+    </div>
+    {% endblock %}
+    {% block site_header_nav %}{% endblock %}
+    {% block site_header_logo %}{% endblock %}
+    {% block breadcrumbs %}{% endblock %}
+  </header>
+{% endblock %}
 
 {% block content %}
-<div id="conditional-download-bar">
-  <div class="content">
-    <div class="message" id="dlbar-oldfx-desktop">
-      {{ _('You’re using an older version of Firefox for desktop.') }}
-      {{ _('Update today to stay fast and safe.') }}
-      <a class="button-flat btn-download" href="{{ url('firefox.new') }}" data-product="Firefox for Desktop, outdated Firefox">{{ _('Download') }}</a>
-    </div>
-    <div class="message" id="dlbar-nonfx">
-      {{ _('Choose Independent.') }}
-      {{ _('Choose Firefox.') }}
-      <a class="button-flat btn-download" href="{{ url('firefox.new') }}" data-product="Firefox for Desktop, other browser">{{ _('Download') }}</a>
-    </div>
-    <div class="message" id="dlbar-nonfx-android">
-      <a rel="external" href="{{ settings.GOOGLE_PLAY_FIREFOX_LINK }}" data-product="Firefox for Android">{{ _('Get Firefox for Android') }}</a>
-    </div>
-    <div class="message" id="dlbar-ios">
-      {{ _('Firefox is coming soon to iOS! <a href="%s">Sign up to learn more</a>.')|format(url('newsletter.ios')) }}
-    </div>
-
-    <button type="button" class="btn-close button-flat" title="{{ _('Close') }}">{{ _('Close') }}</button>
-  </div>{#-- /.content --#}
-</div>{#-- /#conditional-download-bar --#}
-
 <header id="header">
   <div class="content">
-    <div id="moztab">
-      <a href="{{ url('mozorg.home') }}">Mozilla</a>
-    </div>
-
     <h1>
     {% if LANG.startswith('en') %}
       <span><b>Free</b> yourself</span> with {{ high_res_img('img/firefox/family/index/firefox-wordmark.png', {'alt': 'Firefox', 'width': '330', 'height': '95'}) }}

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -418,6 +418,7 @@ PIPELINE_CSS = {
     'firefox_family': {
         'source_filenames': (
             'css/sandstone/sandstone-resp.less',
+            'css/tabzilla/tabzilla-static.less',
             'css/firefox/family/index.less',
         ),
         'output_filename': 'css/firefox-family-bundle.css',

--- a/media/css/firefox/family/index.less
+++ b/media/css/firefox/family/index.less
@@ -57,6 +57,7 @@
 
 // Handy sprite mixin
 .fxfamily-sprite(@posx, @posy) {
+    // note: the tabzilla image in this sprite is no longer used
     background-image: url(/media/img/firefox/family/index/family-sprite.png);
     background-position: @posx @posy;
     background-repeat: no-repeat;
@@ -155,33 +156,12 @@ html.ios {
 
 
 /*--------------------------------------------------------------------------*/
-// Mozilla tab (like tabzilla, but not)
-#moztab {
-    position: absolute;
-    right: 0;
-    top: 0;
-
-    a {
-        .image-replaced();
-        background: url(/media/img/firefox/family/index/family-sprite.png) -90px -556px no-repeat;
-        display: block;
-        width: 148px;
-        height: 36px;
-        position: relative;
-        z-index: 10;
-        .at2x('/media/img/firefox/family/index/family-sprite.png', 500px, 645px);
-    }
+// Tabzillita (little tabzilla) customizations
+#tabzilla {
+    z-index: 3;
 
     &:before {
-        content: '';
-        display: block;
-        width: 88px;
-        height: 26px;
         background: @mozIDBlue;
-        position: absolute;
-        left: 28px;
-        top: 0;
-        z-index: 9;
     }
 }
 


### PR DESCRIPTION
Due to the family nav currently requiring an inverted tabzilla image (blue on light background), which is almost certainly going to change before Q3, I don't think integration between this PR and the nav is a good idea at this time. When the nav gets updated, we'll figure out how to best integrate the changes here.

On a related note, the Firefox Family landing page is the perfect candidate for a live use of the new static tabzilla asset.