### PR TITLE
Move /all to /download/all

### DIFF
--- a/bedrock/base/tests/data/example_sentry_payload.json
+++ b/bedrock/base/tests/data/example_sentry_payload.json
@@ -471,6 +471,6 @@
     },
     "server_name": "bedrock",
     "timestamp": "2022-03-15T11:31:32.496707Z",
-    "transaction": "/en-US/firefox/all/"
+    "transaction": "/en-US/firefox/download/all/"
   }
 }

--- a/bedrock/firefox/templatetags/helpers.py
+++ b/bedrock/firefox/templatetags/helpers.py
@@ -231,7 +231,7 @@ def download_firefox_thanks(ctx, dom_id=None, locale=None, alt_copy=None, button
 @library.global_function
 def firefox_url(platform, page, channel=None):
     """
-    Return a product-related URL like /firefox/all/ or /mobile/beta/notes/.
+    Return a product-related URL like /firefox/download/all/ or /mobile/beta/notes/.
 
     Examples
     ========

--- a/bedrock/firefox/tests/test_helpers.py
+++ b/bedrock/firefox/tests/test_helpers.py
@@ -383,18 +383,18 @@ class TestFirefoxURL(TestCase):
 
     def test_firefox_all(self):
         """Should return a reversed path for the Firefox all downloads page"""
-        assert self._render("desktop", "all").endswith("/firefox/all/desktop-release/")
-        assert self._render("desktop", "all", "release").endswith("/firefox/all/desktop-release/")
-        assert self._render("desktop", "all", "beta").endswith("/firefox/all/desktop-beta/")
-        assert self._render("desktop", "all", "alpha").endswith("/firefox/all/desktop-developer/")
-        assert self._render("desktop", "all", "developer").endswith("/firefox/all/desktop-developer/")
-        assert self._render("desktop", "all", "nightly").endswith("/firefox/all/desktop-nightly/")
-        assert self._render("desktop", "all", "esr").endswith("/firefox/all/desktop-esr/")
-        assert self._render("desktop", "all", "organizations").endswith("/firefox/all/desktop-esr/")
-        assert self._render("android", "all").endswith("/firefox/all/android-release/")
-        assert self._render("android", "all", "release").endswith("/firefox/all/android-release/")
-        assert self._render("android", "all", "beta").endswith("/firefox/all/android-beta/")
-        assert self._render("android", "all", "nightly").endswith("/firefox/all/android-nightly/")
+        assert self._render("desktop", "all").endswith("/firefox/download/all/desktop-release/")
+        assert self._render("desktop", "all", "release").endswith("/firefox/download/all/desktop-release/")
+        assert self._render("desktop", "all", "beta").endswith("/firefox/download/all/desktop-beta/")
+        assert self._render("desktop", "all", "alpha").endswith("/firefox/download/all/desktop-developer/")
+        assert self._render("desktop", "all", "developer").endswith("/firefox/download/all/desktop-developer/")
+        assert self._render("desktop", "all", "nightly").endswith("/firefox/download/all/desktop-nightly/")
+        assert self._render("desktop", "all", "esr").endswith("/firefox/download/all/desktop-esr/")
+        assert self._render("desktop", "all", "organizations").endswith("/firefox/download/all/desktop-esr/")
+        assert self._render("android", "all").endswith("/firefox/download/all/android-release/")
+        assert self._render("android", "all", "release").endswith("/firefox/download/all/android-release/")
+        assert self._render("android", "all", "beta").endswith("/firefox/download/all/android-beta/")
+        assert self._render("android", "all", "nightly").endswith("/firefox/download/all/android-nightly/")
 
     def test_firefox_sysreq(self):
         """Should return a reversed path for the Firefox sysreq page"""

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -22,10 +22,10 @@ ios_sysreq_re = sysreq_re.replace(r"firefox", "firefox/ios")
 
 urlpatterns = (
     path("firefox/", views.FirefoxHomeView.as_view(), name="firefox"),
-    path("firefox/all/", views.firefox_all, name="firefox.all"),
-    path("firefox/all/<slug:product_slug>/", views.firefox_all, name="firefox.all.platforms"),
-    path("firefox/all/<slug:product_slug>/<str:platform>/", views.firefox_all, name="firefox.all.locales"),
-    path("firefox/all/<slug:product_slug>/<str:platform>/<str:locale>/", views.firefox_all, name="firefox.all.download"),
+    path("firefox/download/all/", views.firefox_all, name="firefox.all"),
+    path("firefox/download/all/<slug:product_slug>/", views.firefox_all, name="firefox.all.platforms"),
+    path("firefox/download/all/<slug:product_slug>/<str:platform>/", views.firefox_all, name="firefox.all.locales"),
+    path("firefox/download/all/<slug:product_slug>/<str:platform>/<str:locale>/", views.firefox_all, name="firefox.all.download"),
     page("firefox/channel/desktop/", "firefox/channel/desktop.html", ftl_files=["firefox/channel"]),
     page("firefox/channel/android/", "firefox/channel/android.html", ftl_files=["firefox/channel"]),
     page("firefox/channel/ios/", "firefox/channel/ios.html", ftl_files=["firefox/channel"]),

--- a/bedrock/releasenotes/tests/releases/firefox-55.0a1-nightly.json
+++ b/bedrock/releasenotes/tests/releases/firefox-55.0a1-nightly.json
@@ -22,7 +22,7 @@
       "id": 787108,
       "is_public": true,
       "modified": "2017-08-08T13:08:09.659000+00:00",
-      "note": "Simplified installation process with a streamlined Windows stub installer\r\n\r\n  - Firefox for Windows 64-bit is now installed by default on 64-bit systems with at least 2GB of RAM\r\n  - [Full installers][1] with advanced installation options are still available \r\n\r\n[1]: https://www.mozilla.org/firefox/all/",
+      "note": "Simplified installation process with a streamlined Windows stub installer\r\n\r\n  - Firefox for Windows 64-bit is now installed by default on 64-bit systems with at least 2GB of RAM\r\n  - [Full installers][1] with advanced installation options are still available \r\n\r\n[1]: https://www.firefox.com/download/all/",
       "sort_num": 999,
       "tag": "New"
     },

--- a/bedrock/sitemaps/tests/test_views.py
+++ b/bedrock/sitemaps/tests/test_views.py
@@ -11,7 +11,7 @@ from bedrock.sitemaps.models import NO_LOCALE, SitemapURL
 class TestSitemapView(TestCase):
     def setUp(self):
         data = [
-            {"path": "/firefox/all/", "locale": "de"},
+            {"path": "/firefox/download/all/", "locale": "de"},
             {"path": "/firefox/", "locale": "de"},
             {
                 "path": "/privacy/",
@@ -70,7 +70,7 @@ class TestSitemapView(TestCase):
                 <loc>https://www.mozilla.org/de/firefox/</loc>
               </url>
               <url>
-                <loc>https://www.mozilla.org/de/firefox/all/</loc>
+                <loc>https://www.mozilla.org/de/firefox/download/all/</loc>
               </url>
             </urlset>"""
         )

--- a/profiling/hit_popular_pages.py
+++ b/profiling/hit_popular_pages.py
@@ -22,7 +22,7 @@ import requests
 paths = [
     "/en-US/firefox/",
     "/en-US/firefox/121.0/system-requirements/",
-    "/en-US/firefox/all/",
+    "/en-US/firefox/download/all/",
     "/en-US/firefox/android/124.0/releasenotes/",
     "/en-US/firefox/channel/desktop/",
     "/en-US/firefox/channel/desktop/?reason=manual-update",

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -91,10 +91,10 @@ def pytest_generate_tests(metafunc):
 
         elif "download_path_l10n" in metafunc.fixturenames:
             urls = []
-            doc = get_web_page(f"{base_url}/en-US/firefox/all/")
+            doc = get_web_page(f"{base_url}/en-US/firefox/download/all/")
             product_urls = [a.attrib["href"] for a in doc("ul.c-product-list a")]
-            # If product url links outside of /firefox/all/ ignore it. (e.g. testflight)
-            product_urls = [url for url in product_urls if url.startswith("/en-US/firefox/all/")]
+            # If product url links outside of /firefox/download/all/ ignore it. (e.g. testflight)
+            product_urls = [url for url in product_urls if url.startswith("/en-US/firefox/download/all/")]
             for url in product_urls:
                 doc = get_web_page(f"{base_url}{url}")
                 platform_urls = [a.attrib["href"] for a in doc("ul.c-platform-list a")]

--- a/tests/pages/firefox/all.py
+++ b/tests/pages/firefox/all.py
@@ -9,7 +9,7 @@ from pages.regions.modal import ModalProtocol
 
 
 class FirefoxAllPage(BasePage):
-    _URL_TEMPLATE = "/{locale}/firefox/all/{slug}"
+    _URL_TEMPLATE = "/{locale}/firefox/download/all/{slug}"
 
     # help modals
 

--- a/tests/playwright/specs/a11y/includes/urls.js
+++ b/tests/playwright/specs/a11y/includes/urls.js
@@ -12,13 +12,13 @@
  */
 const desktopTestURLs = [
     '/en-US/firefox/',
-    '/en-US/firefox/all/',
     '/en-US/firefox/channel/android/',
     '/en-US/firefox/channel/desktop/',
     '/en-US/firefox/developer/',
+    '/en-US/firefox/download/',
+    '/en-US/firefox/download/all/',
     '/en-US/firefox/download/thanks/',
     '/en-US/firefox/enterprise/',
-    '/en-US/firefox/download/',
     '/en-US/firefox/releasenotes/',
     '/en-US/privacy/websites/cookie-settings/'
 ];

--- a/tests/unit/spec/base/consent/consent-utils.js
+++ b/tests/unit/spec/base/consent/consent-utils.js
@@ -333,7 +333,7 @@ describe('isURLPermitted()', function () {
     it('should return false for pathnames not in the allow-list', function () {
         expect(isURLPermitted('/en-US/firefox/')).toBeFalse();
         expect(isURLPermitted('/en-US/firefox/download/')).toBeFalse();
-        expect(isURLPermitted('/en-US/firefox/all/')).toBeFalse();
+        expect(isURLPermitted('/en-US/firefox/download/all/')).toBeFalse();
         expect(
             isURLPermitted('/en-US/firefox/124.0.2/releasenotes/')
         ).toBeFalse();

--- a/tests/unit/spec/base/datalayer-productdownload.js
+++ b/tests/unit/spec/base/datalayer-productdownload.js
@@ -60,9 +60,9 @@ describe('TrackProductDownload.isValidDownloadURL', function () {
         );
         expect(testMsStoreURL).toBe(true);
     });
-    it('should not accept a random link to mozilla.org as a valid URL', function () {
+    it('should not accept a random link to firefox.com as a valid URL', function () {
         const testRandomURL = TrackProductDownload.isValidDownloadURL(
-            'https://www.mozilla.org/en-US/firefox/all/'
+            'https://www.firefox.com/en-US/firefox/download/all/'
         );
         expect(testRandomURL).toBe(false);
     });


### PR DESCRIPTION
## One-line summary

Moves `/firefox/all/` (and child URLs) to `/firefox/download/all/`

## Issue / Bugzilla link

N/A

## Testing

http://localhost:8000/en-US/firefox/download/all/